### PR TITLE
Fix runtime errors at the event handlers with CustomEventWrapper.

### DIFF
--- a/lib/td_input.dart
+++ b/lib/td_input.dart
@@ -14,7 +14,7 @@ class TodoInput extends InputElement with PolymerMixin, PolymerBase {
   keyPressAction(e, [_]) {
     // Listen for enter on keypress but esc on keyup, because
     // IE doesn't fire keyup for enter.
-    if (e.keyCode == KeyCode.ENTER) {
+    if ((e.original as KeyboardEvent).keyCode == KeyCode.ENTER) {
       e.preventDefault();
       fire('td-input-commit');
     }
@@ -22,7 +22,7 @@ class TodoInput extends InputElement with PolymerMixin, PolymerBase {
 
   @Listen('keyup')
   keyUpAction(e, [_]) {
-    if (e.keyCode == KeyCode.ESC) {
+    if ((e.original as KeyboardEvent).keyCode == KeyCode.ESC) {
       fire('td-input-cancel');
     }
   }

--- a/lib/td_todos.dart
+++ b/lib/td_todos.dart
@@ -122,7 +122,7 @@ class TodoList extends PolymerElement {
   }
 
   @reflectable
-  void filterAction(MouseEvent e, [_]) {
+  void filterAction(e, [_]) {
     if (e.target is! AnchorElement) return;
     var target = e.target as AnchorElement;
     set('filter', target.parent.attributes['label']);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: todomvc
 description: TodoMVC built with the polymer.dart package
-version: 0.15.3
+version: 0.15.4
 dependencies:
-  polymer: ^1.0.0-rc.11
+  polymer: ^1.0.0-rc.13
   web_components: ^0.12.0
   browser: ^0.10.0
 transformers:


### PR DESCRIPTION
* Use e.original for keyCode getter.
* Omit MouseEvent type to fix type mismatch error.
* Update polymer to rc-13.